### PR TITLE
Fixed focus lock bug. Version 1.00 Release.

### DIFF
--- a/Firmware/MX3_LightMotion/MX3_CameraControl.ino
+++ b/Firmware/MX3_LightMotion/MX3_CameraControl.ino
@@ -132,6 +132,7 @@ void camCallBack(byte code) {
   // function is called in an interrupt and can daisy-chain under certain configurations,
   // which can result in unexpected behavior
   
+  
   if( code == OM_CAM_FFIN ) {
       // focus done
     Engine.state(ST_EXP);

--- a/Firmware/MX3_LightMotion/MX3_ControlCycle.ino
+++ b/Firmware/MX3_LightMotion/MX3_ControlCycle.ino
@@ -88,6 +88,8 @@ void cycleCamera() {
       return;
   }
     
+   //Change the focus lock. We could check if it has changed but that would take more cycles. 
+   Camera.exposureFocus(camera_focLock);
     
     // if enough time has passed, and we're ok to take an exposure
     // note: for slaves, we only get here by a master signal, so we don't check interval timing

--- a/Firmware/MX3_LightMotion/MX3_Core.h
+++ b/Firmware/MX3_LightMotion/MX3_Core.h
@@ -248,7 +248,7 @@ struct MotorDefinition {
 
  // stored memory layout version
  // this number MUST be changed every time the memory layout is changed
-const unsigned int MEMORY_VERSION    = 26;
+const unsigned int MEMORY_VERSION    = 27;
 
 
 /* Locations of each variable to be stored, note correct spacing

--- a/Firmware/MX3_LightMotion/MX3_UI.h
+++ b/Firmware/MX3_LightMotion/MX3_UI.h
@@ -78,7 +78,7 @@ const int BUT_MAP[5][2] = {
 // ====== Memory Strings Used in the UI ========
 
 const char MX3_VERSTR[]  =  "LightMotion";
-const char MX3_SUBSTR[]  =  "v.0.07 (HareXIV)";
+const char MX3_SUBSTR[]  =  "v.1.00 (HareXV)";
 const char MX3_C1STR[]   =  "(c) 2013 Dynamic";
 const char MX3_C2STR[]   =  "Perception";
   // run, stop, and ext must be exact same length, pad with spaces


### PR DESCRIPTION
Focus lock menu option didn't call the camera value. Called function in
ControlCycle.
